### PR TITLE
Fix DockerFile BUG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y nodejs npm && \
     npm install -g npm@latest
 
 # Create a global virtualenv


### PR DESCRIPTION
In older versions of Linux, installing Node.js does not automatically include npm, so it needs to be installed explicitly.